### PR TITLE
Destroy Service Account for the fake service gem

### DIFF
--- a/fake/lib/ey_services_fake/reacharound_awsm.rb
+++ b/fake/lib/ey_services_fake/reacharound_awsm.rb
@@ -123,6 +123,7 @@ module EyServicesFake
     def disable_service(service_account_id)
       service_account = ServiceAccount.get(service_account_id)
       @connection.delete(service_account.url)
+      service_account.destroy
     end
 
     def provision_service(sso_account_id, service_account_id, app_deployment_id)


### PR DESCRIPTION
When a customer destroys their add-on, then adds the add-on to their account again, I would expect a new POST request would be made to the service_accounts_url.

Currently the fake service does not clear the old service_account configuration, and no POST request is made.

Obviously, if this is the desired behavior, please reject this pull request.

I've added the line to the fake service to remove the service_account. When the add-on is removed then re-added to an EY account, a new POST request is made to the service_account_url.

Thanks,
J
